### PR TITLE
Ensure ARM7 ROM offset is always above 0x8000.

### DIFF
--- a/source/ndscreate.cpp
+++ b/source/ndscreate.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 
 unsigned int arm9_align = 0x1FF;
+unsigned int arm7_min = 0x8000;
 unsigned int arm7_align = 0x1FF;
 unsigned int fnt_align = 0x1FF;		// 0x3 0x1FF
 unsigned int fat_align = 0x1FF;		// 0x3 0x1FF
@@ -470,7 +471,7 @@ void Create()
 	// fseek(fNDS, 1388772, SEEK_CUR);		// test for ASME
 
 	// ARM7 binary
-	header.arm7_rom_offset = (ftell(fNDS) + arm7_align) &~ arm7_align;
+	header.arm7_rom_offset = std::max((ftell(fNDS) + arm7_align) &~ arm7_align, static_cast<long>(arm7_min));
 	fseek(fNDS, header.arm7_rom_offset, SEEK_SET);
 
 	// if (arm7filename)


### PR DESCRIPTION
This PR ensures that the ARM7 binary is at or above ROM offset 0x8000.

The reason is that the native DS loader (bios/firmware) doesn't seem to like ROMs with ARM7 below 0x8000. GBATEK confirms this, it says `ARM7 rom_offset    (8000h and up)`. I've confirmed it experimenally too.