### PR TITLE
Fix sbox data offset.

### DIFF
--- a/source/encryption.cpp
+++ b/source/encryption.cpp
@@ -476,7 +476,7 @@ void EnDecryptSecureArea(char *ndsfilename, char endecrypt_option)
 	bool do_decrypt = (endecrypt_option == 'd');
 	bool do_encrypt = (endecrypt_option == 'e') || (endecrypt_option == 'E');
 	unsigned int rounds_offsets = (endecrypt_option == 'E') ? 0x2000 : 0x1600;
-	unsigned int sbox_offsets = (endecrypt_option == 'E') ? 0x2400 : 0x2800;
+	unsigned int sbox_offsets = (endecrypt_option == 'E') ? 0x2400 : 0x1c00;
 
 	// check if ROM is already encrypted
 	if (romType == ROMTYPE_NDSDUMPED)


### PR DESCRIPTION
Nintendo cards have the sbox data at 0x1c00-0x2c00, not at 0x2800-0x3800.

Evidence:
- Writing an encrypted ROM to a rewritable dev flash card works with offset 0x1c00, not with 0x2800. (tested myself)
- There are some ROMs out there that have the encryption data filled in, and they have the sbox data at 0x1c00. for example "x085 - Contra 4 (Europe) (Proto).nds"
- The sbox data is 0x1000 bytes long, so it overlaps with the "test patterns", you only end up with half of the sbox data in the ROM with current ndstool. Doesn't look right.

The last point also applies to the "other" offsets, but I don't know what they are from, so I didn't change them.