### PR TITLE
Fix banners over 0x840 bytes

### DIFF
--- a/source/ndscreate.cpp
+++ b/source/ndscreate.cpp
@@ -545,7 +545,6 @@ void Create()
 		if (bannerfilename)
 		{
 			header.banner_offset = (header.fat_offset + header.fat_size + banner_align) &~ banner_align;
-			file_top = header.banner_offset + 0x840;
 			fseek(fNDS, header.banner_offset, SEEK_SET);
 			if (bannertype == BANNER_IMAGE)
 			{
@@ -563,8 +562,15 @@ void Create()
 			}
 			else
 			{
+				FILE *banner = fopen(bannerfilename, "rb");
+				fseek(banner, 0, SEEK_END);
+				bannersize = ftell(banner);
+				fclose(banner);
+
 				CopyFromBin(bannerfilename, 0);
 			}
+
+			file_top = header.banner_offset + bannersize;
 		}
 		else
 		{
@@ -732,7 +738,7 @@ void Create()
 		header.access_control = accessControl;
 		header.scfg_ext_mask = scfgExtMask;
 		header.appflags = appFlags;
-		header.banner_size = 2112;
+		header.banner_size = bannersize;
 		header.offset_0x20C = 0x00010000;
 		header.offset_0x218 = 0x0004D084;
 		header.offset_0x21C = 0x0000052C;

--- a/source/ndstool.cpp
+++ b/source/ndstool.cpp
@@ -466,7 +466,29 @@ int main(int argc, char *argv[])
 			case ACTION_EXTRACT:
 				fNDS = fopen(ndsfilename, "rb");
 				if (!fNDS) { fprintf(stderr, "Cannot open file '%s'.\n", ndsfilename); exit(1); }
-				fread(&header, 512, 1, fNDS);
+				fread(&header, sizeof(Header), 1, fNDS);
+				if (header.unitcode & 2) {
+					bannersize = header.banner_size;
+				} else {
+					fseek(fNDS, header.banner_offset, SEEK_SET);
+					unsigned short bannerversion;
+					fread(&bannerversion, 2, 1, fNDS);
+					switch(bannerversion) {
+						case 0x0001:
+						default:
+							bannersize = 0x840;
+							break;
+						case 0x0002:
+							bannersize = 0x940;
+							break;
+						case 0x0003:
+							bannersize = 0xA40;
+							break;
+						case 0x0103:
+							bannersize = 0x23C0;
+							break;
+					}
+				}
 				fclose(fNDS);
 
 			printf("9i %s, 7i %s, unitcode %x\n",arm9ifilename,arm7ifilename, header.unitcode);

--- a/source/ndstool.cpp
+++ b/source/ndstool.cpp
@@ -31,6 +31,7 @@ char *arm7ovltablefilename = 0;
 char *arm9ovltablefilename = 0;
 char *bannerfilename = 0;
 char *bannertext = 0;
+long bannersize = 0x840;
 //bool compatibility = false;
 char *headerfilename_or_size = 0;
 //char *uniquefilename = 0;
@@ -475,7 +476,7 @@ int main(int argc, char *argv[])
 					if (arm9ifilename) Extract(arm9ifilename, true, 0x1C0, true, 0x1CC, true);
 					if (arm7ifilename) Extract(arm7ifilename, true, 0x1D0, true, 0x1DC);
 				}
-				if (bannerfilename) Extract(bannerfilename, true, 0x68, false, 0x840);
+				if (bannerfilename) Extract(bannerfilename, true, 0x68, false, bannersize);
 				if (headerfilename_or_size) Extract(headerfilename_or_size, false, 0x0, false, 0x200);
 				if (logofilename) Extract(logofilename, false, 0xC0, false, 156);	// *** bin only
 				if (arm9ovltablefilename) Extract(arm9ovltablefilename, true, 0x50, true, 0x54);

--- a/source/ndstool.h
+++ b/source/ndstool.h
@@ -46,6 +46,7 @@ extern char *arm9ovltablefilename;
 extern char *bannerfilename;
 extern char *bannertext;
 extern int bannertype;
+extern long bannersize;
 //extern bool compatibility;
 extern char *headerfilename_or_size;
 extern char *uniquefilename;


### PR DESCRIPTION
Fixes banners over 0x840 bytes, since version 2 is 0x940 bytes, version 3 is 0xA40 bytes and version 0x0103 is 0x23C0 bytes. This means that banners with animated icons and Chinese/Korean banners are possible. Only affects importing `banner.bin` files, providing an image and title is left as is.
